### PR TITLE
Fix potential problems

### DIFF
--- a/R/populate.R
+++ b/R/populate.R
@@ -70,14 +70,17 @@ to_symbol_encoding <- function(x) enc2native(x)
 
 make_make_active_binding_fun <- function(.envir) {
   make_active_binding_fun <- function(name, fun, ...) {
-    force(name)
     force(fun)
-    list(...)
+    extra <- list(...)
+    if (length(extra) == 0)
+      args <- list(name)
+    else
+      args <- c(list(name), extra)
     function(value) {
       if (!missing(value)) {
         stop("Binding is read-only.", call. = FALSE)
       }
-      fun(name, ...)
+      rlang::invoke(fun, args)
     }
   }
 

--- a/R/populate.R
+++ b/R/populate.R
@@ -70,17 +70,14 @@ to_symbol_encoding <- function(x) enc2native(x)
 
 make_make_active_binding_fun <- function(.envir) {
   make_active_binding_fun <- function(name, fun, ...) {
+    force(name)
     force(fun)
-    extra <- list(...)
-    if (length(extra) == 0)
-      args <- list(name)
-    else
-      args <- c(list(name), extra)
+    list(...)
     function(value) {
       if (!missing(value)) {
         stop("Binding is read-only.", call. = FALSE)
       }
-      rlang::invoke(fun, args)
+      fun(name, ...)
     }
   }
 

--- a/R/populate.R
+++ b/R/populate.R
@@ -71,6 +71,7 @@ to_symbol_encoding <- function(x) enc2native(x)
 make_make_active_binding_fun <- function(.envir) {
   make_active_binding_fun <- function(name, fun, ...) {
     force(name)
+    force(fun)
     list(...)
     function(value) {
       if (!missing(value)) {


### PR DESCRIPTION
related to tidyverse/dplyr#2811.

- When creating a closure, force all arguments that remain constant.
- Use `rlang::invoke()` instead of `...` to pass payload.