### PR TITLE
fledge: CRAN release v0.1.2

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,4 @@
 ^docs$
 ^\.github$
 ^revdep$
+^index\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bindr
 Title: Parametrized Active Bindings
-Version: 0.1.1.9900
+Version: 0.1.2
 Authors@R: c(
     person("Kirill", "M\u00fcller", role = c("aut", "cre"), email = "kirill@cynkra.com", comment = c(ORCID = "0000-0002-1416-3412")),
     person("RStudio", role = c("cph", "fnd"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# bindr 0.1.1.9900 (2024-11-21)
+# bindr 0.1.2 (2024-11-21)
 
 ## Feature
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,30 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
-bindr [![Travis-CI Build Status](https://app.travis-ci.com/krlmlr/bindr.svg?branch=master)](https://app.travis-ci.com/krlmlr/bindr) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/krlmlr/bindr?branch=master&svg=true)](https://ci.appveyor.com/project/krlmlr/bindr) [![Coverage Status](https://img.shields.io/codecov/c/github/krlmlr/bindr/master.svg)](https://app.codecov.io/github/krlmlr/bindr?branch=master) [![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/bindr)](https://cran.r-project.org/package=bindr)
-======================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================
 
-Active bindings in R are much like properties in other languages: They look like a variable, but querying or setting the value triggers a function call. They can be created in R via [`makeActiveBinding()`](https://www.rdocumentation.org/packages/base/versions/3.3.1/topics/bindenv), but with this API the function used to compute or change the value of a binding cannot take additional arguments. The `bindr` package faciliates the creation of active bindings that are linked to a function that receives the binding name, and an arbitrary number of additional arguments.
+# bindr
 
-Installation
-------------
+<!-- badges: start -->
+
+[![Lifecycle:
+stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html)
+[![R build
+status](https://github.com/krlmlr/bindr/workflows/rcc/badge.svg)](https://github.com/krlmlr/bindr/actions)
+[![Coverage
+Status](https://img.shields.io/codecov/c/github/krlmlr/bindr/master.svg)](https://app.codecov.io/github/krlmlr/bindr?branch=master)
+[![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/bindr)](https://cran.r-project.org/package=bindr)
+<!-- badges: end -->
+
+Active bindings in R are much like properties in other languages: They
+look like a variable, but querying or setting the value triggers a
+function call. They can be created in R via
+[`makeActiveBinding()`](https://www.rdocumentation.org/packages/base/versions/3.3.1/topics/bindenv),
+but with this API the function used to compute or change the value of a
+binding cannot take additional arguments. The `bindr` package faciliates
+the creation of active bindings that are linked to a function that
+receives the binding name, and an arbitrary number of additional
+arguments.
+
+## Installation
 
 You can install `bindr` from GitHub with:
 
@@ -15,10 +33,11 @@ You can install `bindr` from GitHub with:
 devtools::install_github("krlmlr/bindr")
 ```
 
-Getting started
----------------
+## Getting started
 
-For illustration, the `append_random()` function is used. This function appends a separator (a dash by default) and a random letter to its input, and talks about it, too.
+For illustration, the `append_random()` function is used. This function
+appends a separator (a dash by default) and a random letter to its
+input, and talks about it, too.
 
 ``` r
 set.seed(20161510)
@@ -29,32 +48,35 @@ append_random <- function(x, sep = "-") {
 
 append_random("a")
 #> Evaluating append_random(sep = "-")
-#> [1] "a-k"
+#> [1] "a-h"
 append_random("X", sep = "+")
 #> Evaluating append_random(sep = "+")
-#> [1] "X+u"
+#> [1] "X+k"
 ```
 
-In this example, we create an environment that contains bindings for all lowercase letters, which are evaluated with `append_random()`. As a result, a dash and a random letter are appended to the name of the binding:
+In this example, we create an environment that contains bindings for all
+lowercase letters, which are evaluated with `append_random()`. As a
+result, a dash and a random letter are appended to the name of the
+binding:
 
 ``` r
 library(bindr)
 env <- create_env(letters, append_random)
 ls(env)
-#>  [1] "a" "b" "c" "d" "e" "f" "g" "h" "i" "j" "k" "l" "m" "n" "o" "p" "q"
-#> [18] "r" "s" "t" "u" "v" "w" "x" "y" "z"
+#>  [1] "a" "b" "c" "d" "e" "f" "g" "h" "i" "j" "k" "l" "m" "n" "o" "p" "q" "r" "s"
+#> [20] "t" "u" "v" "w" "x" "y" "z"
 env$a
 #> Evaluating append_random(sep = "-")
-#> [1] "a-p"
+#> [1] "a-s"
 env$a
 #> Evaluating append_random(sep = "-")
-#> [1] "a-j"
+#> [1] "a-h"
 env$a
 #> Evaluating append_random(sep = "-")
-#> [1] "a-b"
+#> [1] "a-c"
 env$c
 #> Evaluating append_random(sep = "-")
-#> [1] "c-b"
+#> [1] "c-o"
 env$Z
 #> NULL
 ```
@@ -63,16 +85,41 @@ Bindings can also be added to existing environments:
 
 ``` r
 populate_env(env, LETTERS, append_random, "+")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
 env$a
 #> Evaluating append_random(sep = "-")
-#> [1] "a-z"
+#> [1] "a-q"
 env$Z
 #> Evaluating append_random(sep = "+")
-#> [1] "Z+j"
+#> [1] "Z+c"
 ```
 
-Further properties
-------------------
+## Further properties
 
 Both named and unnamed arguments are supported:
 
@@ -91,7 +138,7 @@ env2$b
 #> NULL
 get("b", env2)
 #> Evaluating append_random(sep = "-")
-#> [1] "b-m"
+#> [1] "b-t"
 ```
 
 The bindings by default have access to the calling environment:
@@ -128,12 +175,19 @@ populate_env(env4, letters, identity)
 #> Error in populate_env(env4, letters, identity): Not creating bindings for existing variables: b, a
 ```
 
-Active bindings and C++
------------------------
+## Active bindings and C++
 
-Active bindings must be R functions. To interface with C++ code, one must bind against an exported Rcpp function, possibly with `rng = false` if performance matters. The [`bindrcpp`](https://github.com/krlmlr/bindrcpp#readme) package uses `bindr` to provide an easy-to-use C++ interface for parametrized active bindings, and is the recommended way to interface with C++ code. In the remainder of this section, an alternative using an exported C++ function is shown.
+Active bindings must be R functions. To interface with C++ code, one
+must bind against an exported Rcpp function, possibly with `rng = false`
+if performance matters. The
+[`bindrcpp`](https://github.com/krlmlr/bindrcpp#readme) package uses
+`bindr` to provide an easy-to-use C++ interface for parametrized active
+bindings, and is the recommended way to interface with C++ code. In the
+remainder of this section, an alternative using an exported C++ function
+is shown.
 
-The following C++ module exports a function `change_case(to_upper = FALSE)`, which is bound against in R code later.
+The following C++ module exports a function
+`change_case(to_upper = FALSE)`, which is bound against in R code later.
 
 ``` cpp
 #include <Rcpp.h>

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-bindr 0.1.1.9900
+bindr 0.1.2
 
 ## Cran Repository Policy
 

--- a/index.md
+++ b/index.md
@@ -1,37 +1,7 @@
----
-output:
-  github_document:
-    html_preview: false
----
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-```{r, include = FALSE}
-knitr::opts_chunk$set(
-  collapse = TRUE,
-  comment = "#>",
-  fig.path = "README-"
-)
 
-pkgload::load_all()
-
-clean_output <- function(x, options) {
-  index <- x
-  index <- gsub("─", "-", index)
-  index <- strsplit(paste(index, collapse = "\n"), "\n---\n")[[1]][[2]]
-  writeLines(index, "index.md")
-
-  x <- fansi::strip_sgr(x)
-  x
-}
-
-options(cli.num_colors = 256)
-
-local({
-  hook_source <- knitr::knit_hooks$get("document")
-  knitr::knit_hooks$set(document = clean_output)
-})
-```
 
 # bindr 
 
@@ -56,7 +26,8 @@ and an arbitrary number of additional arguments.
 
 You can install `bindr` from GitHub with:
 
-```{r gh-installation, eval = FALSE}
+
+``` r
 # install.packages("devtools")
 devtools::install_github("krlmlr/bindr")
 ```
@@ -68,7 +39,8 @@ For illustration, the `append_random()` function is used.
 This function appends a separator (a dash by default) and a random letter
 to its input, and talks about it, too.
 
-```{r append-random}
+
+``` r
 set.seed(20161510)
 append_random <- function(x, sep = "-") {
   message("Evaluating append_random(sep = ", deparse(sep), ")")
@@ -76,30 +48,77 @@ append_random <- function(x, sep = "-") {
 }
 
 append_random("a")
+#> Evaluating append_random(sep = "-")
+#> [1] "a-h"
 append_random("X", sep = "+")
+#> Evaluating append_random(sep = "+")
+#> [1] "X+k"
 ```
 
 In this example, we create an environment that contains bindings
 for all lowercase letters, which are evaluated with `append_random()`.
 As a result, a dash and a random letter are appended to the name of the binding:
 
-```{r create}
+
+``` r
 library(bindr)
 env <- create_env(letters, append_random)
 ls(env)
+#>  [1] "a" "b" "c" "d" "e" "f" "g" "h" "i" "j" "k" "l" "m" "n" "o" "p" "q" "r" "s"
+#> [20] "t" "u" "v" "w" "x" "y" "z"
 env$a
+#> Evaluating append_random(sep = "-")
+#> [1] "a-s"
 env$a
+#> Evaluating append_random(sep = "-")
+#> [1] "a-h"
 env$a
+#> Evaluating append_random(sep = "-")
+#> [1] "a-c"
 env$c
+#> Evaluating append_random(sep = "-")
+#> [1] "c-o"
 env$Z
+#> NULL
 ```
 
 Bindings can also be added to existing environments:
 
-```{r populate}
+
+``` r
 populate_env(env, LETTERS, append_random, "+")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
+#> Evaluating append_random(sep = "-")
 env$a
+#> Evaluating append_random(sep = "-")
+#> [1] "a-q"
 env$Z
+#> Evaluating append_random(sep = "+")
+#> [1] "Z+c"
 ```
 
 
@@ -107,22 +126,30 @@ env$Z
 
 Both named and unnamed arguments are supported:
 
-```{r named-unnamed}
+
+``` r
 create_env("binding", paste, "value", sep = "-")$binding
+#> [1] "binding-value"
 ```
 
 A parent environment can be specified for creation:
 
-```{r parent-env}
+
+``` r
 env2 <- create_env("a", identity, .enclos = env)
 env2$a
+#> a
 env2$b
+#> NULL
 get("b", env2)
+#> Evaluating append_random(sep = "-")
+#> [1] "b-t"
 ```
 
 The bindings by default have access to the calling environment:
 
-```{r env-access}
+
+``` r
 create_local_env <- function(names) {
   paste_with_dash <- function(...) paste(..., sep = "-")
   binder <- function(name, append) paste_with_dash(name, append)
@@ -131,23 +158,30 @@ create_local_env <- function(names) {
 
 env3 <- create_local_env("a")
 env3$a
+#> [1] "a-appending"
 ```
 
 All bindings are read-only:
 
-```{r failing, error=TRUE}
+
+``` r
 env3$a <- NA
+#> Error: Binding is read-only.
 env3$a <- NULL
+#> Error: Binding is read-only.
 ```
 
 
 Existing variables or bindings are not overwritten:
 
-```{r overwrite, error=TRUE}
+
+``` r
 env4 <- as.environment(list(a = 5))
 populate_env(env4, list(quote(b)), identity)
 ls(env4)
+#> [1] "a" "b"
 populate_env(env4, letters, identity)
+#> Error in populate_env(env4, letters, identity): Not creating bindings for existing variables: b, a
 ```
 
 
@@ -164,7 +198,8 @@ an alternative using an exported C++ function is shown.
 The following C++ module exports a function `change_case(to_upper = FALSE)`,
 which is bound against in R code later.
 
-```{Rcpp cpp-mod, cache = TRUE}
+
+``` cpp
 #include <Rcpp.h>
 
 #include <algorithm>
@@ -183,10 +218,14 @@ SEXP change_case(Symbol name, bool to_upper = false) {
 
 Binding from R:
 
-```{r bind-cpp-from-r}
+
+``` r
 env <- create_env(list(as.name("__ToLower__")), change_case)
 populate_env(env, list(as.name("__tOuPPER__")), change_case, TRUE)
 ls(env)
+#> [1] "__ToLower__" "__tOuPPER__"
 env$`__ToLower__`
+#> [1] "__tolower__"
 get("__tOuPPER__", env)
+#> [1] "__TOUPPER__"
 ```


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2024-11-21, problems found: https://cran.r-project.org/web/checks/check_results_bindr.html
- [x] NOTE: r-patched-linux-x86_64, r-release-linux-x86_64, r-release-macos-arm64, r-release-macos-x86_64, r-release-windows-x86_64, r-oldrel-macos-arm64, r-oldrel-macos-x86_64, r-oldrel-windows-x86_64
     'LazyData' is specified without a 'data' directory

Check results at: https://cran.r-project.org/web/checks/check_results_bindr.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`