### PR TITLE
fledge: CRAN release v0.1.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bindr
 Title: Parametrized Active Bindings
-Version: 0.1.2.9015
+Version: 0.1.3
 Authors@R: c(
     person("Kirill", "M\u00fcller", role = c("aut", "cre"), email = "kirill@cynkra.com", comment = c(ORCID = "0000-0002-1416-3412")),
     person("RStudio", role = c("cph", "fnd"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,14 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# bindr 0.1.2.9015 (2025-11-18)
+# bindr 0.1.3 (2025-12-01)
+
+## fledge
+
+- Bump version to 0.1.2.9002 (#14).
+
+- Bump version to 0.1.2.9001 (#13).
+
+- Bump version to 0.1.2.9000 (#12).
 
 ## Chore
 
@@ -8,21 +16,11 @@
 
 - Migrate from defunct `with_mock()` to `with_mocked_bindings()` (#45, #54).
 
-
-# bindr 0.1.2.9014 (2025-11-17)
+- Auto-update from GitHub Actions (#46).
 
 ## Continuous integration
 
 - Install binaries from r-universe for dev workflow (#52).
-
-
-# bindr 0.1.2.9013 (2025-11-12)
-
-## Chore
-
-- Auto-update from GitHub Actions (#46).
-
-## Continuous integration
 
 - Fix reviewdog and add commenting workflow (#50).
 
@@ -52,32 +50,12 @@
 
 - Sync (#35).
 
-
-# bindr 0.1.2.9012 (2024-12-09)
-
-## Continuous integration
-
 - Avoid failure in fledge workflow if no changes (#32).
-
-
-# bindr 0.1.2.9011 (2024-12-08)
-
-## Continuous integration
 
 - Fetch tags for fledge workflow to avoid unnecessary NEWS entries (#30).
 
-
-# bindr 0.1.2.9010 (2024-12-07)
-
-## Continuous integration
-
 - Use larger retry count for lock-threads workflow (#28).
 
-
-# bindr 0.1.2.9009 (2024-12-01)
-
-## Continuous integration
-
 - Ignore errors when removing pkg-config on macOS (#23).
 
 - Explicit permissions (#21).
@@ -89,145 +67,10 @@
 - Fix macOS (#16).
 
 - Use Ubuntu 24.04 and styler PR (#15).
-
-## fledge
-
-- Bump version to 0.1.2.9002 (#14).
-
-
-# bindr 0.1.2.9008 (2024-11-30)
-
-## Continuous integration
-
-- Ignore errors when removing pkg-config on macOS (#23).
-
-- Explicit permissions (#21).
-
-- Use styler from main branch (#19).
-
-- Need to install R on Ubuntu 24.04 (#17).
-
-- Fix macOS (#16).
-
-- Use Ubuntu 24.04 and styler PR (#15).
-
-## fledge
-
-- Bump version to 0.1.2.9002 (#14).
-
-
-# bindr 0.1.2.9007 (2024-11-29)
-
-## Continuous integration
-
-- Ignore errors when removing pkg-config on macOS (#23).
-
-- Explicit permissions (#21).
-
-- Use styler from main branch (#19).
-
-- Need to install R on Ubuntu 24.04 (#17).
-
-- Fix macOS (#16).
-
-- Use Ubuntu 24.04 and styler PR (#15).
-
-## fledge
-
-- Bump version to 0.1.2.9002 (#14).
-
-
-# bindr 0.1.2.9006 (2024-11-28)
-
-## Continuous integration
-
-- Ignore errors when removing pkg-config on macOS (#23).
-
-- Explicit permissions (#21).
-
-- Use styler from main branch (#19).
-
-- Need to install R on Ubuntu 24.04 (#17).
-
-- Fix macOS (#16).
-
-- Use Ubuntu 24.04 and styler PR (#15).
-
-## fledge
-
-- Bump version to 0.1.2.9002 (#14).
-
-
-# bindr 0.1.2.9005 (2024-11-27)
-
-## Continuous integration
-
-- Explicit permissions (#21).
-
-- Use styler from main branch (#19).
-
-- Need to install R on Ubuntu 24.04 (#17).
-
-- Fix macOS (#16).
-
-- Use Ubuntu 24.04 and styler PR (#15).
-
-## fledge
-
-- Bump version to 0.1.2.9002 (#14).
-
-
-# bindr 0.1.2.9004 (2024-11-26)
-
-## Continuous integration
-
-- Use styler from main branch (#19).
-
-- Need to install R on Ubuntu 24.04 (#17).
-
-- Fix macOS (#16).
-
-- Use Ubuntu 24.04 and styler PR (#15).
-
-## fledge
-
-- Bump version to 0.1.2.9002 (#14).
-
-
-# bindr 0.1.2.9003 (2024-11-25)
-
-## Continuous integration
-
-- Need to install R on Ubuntu 24.04 (#17).
-
-- Fix macOS (#16).
-
-- Use Ubuntu 24.04 and styler PR (#15).
-
-## fledge
-
-- Bump version to 0.1.2.9002 (#14).
-
-
-# bindr 0.1.2.9002 (2024-11-24)
-
-## fledge
-
-  - Bump version to 0.1.2.9001 (#13).
-
-
-# bindr 0.1.2.9001 (2024-11-23)
-
-## fledge
-
-  - Bump version to 0.1.2.9000 (#12).
-
-
-# bindr 0.1.2.9000 (2024-11-22)
 
 ## Documentation
 
-  - Dev mode.
+- Dev mode.
 
 
 # bindr 0.1.2 (2024-11-21)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,75 +2,9 @@
 
 # bindr 0.1.3 (2025-12-01)
 
-## fledge
-
-- Bump version to 0.1.2.9002 (#14).
-
-- Bump version to 0.1.2.9001 (#13).
-
-- Bump version to 0.1.2.9000 (#12).
-
 ## Chore
 
-- Set up Copilot instructions following rigraph pattern (#55, #56).
-
 - Migrate from defunct `with_mock()` to `with_mocked_bindings()` (#45, #54).
-
-- Auto-update from GitHub Actions (#46).
-
-## Continuous integration
-
-- Install binaries from r-universe for dev workflow (#52).
-
-- Fix reviewdog and add commenting workflow (#50).
-
-- Use workflows for fledge (#49).
-
-- Sync (#48).
-
-- Use reviewdog for external PRs (#47).
-
-- Cleanup and fix macOS (#44).
-
-- Format with air, check detritus, better handling of `extra-packages` (#43).
-
-- Enhance permissions for workflow (#42).
-
-- Permissions, better tests for missing suggests, lints (#41).
-
-- Only fail covr builds if token is given (#40).
-
-- Always use `_R_CHECK_FORCE_SUGGESTS_=false` (#39).
-
-- Correct installation of xml2 (#38).
-
-- Explain (#37).
-
-- Add xml2 for covr, print testthat results (#36).
-
-- Sync (#35).
-
-- Avoid failure in fledge workflow if no changes (#32).
-
-- Fetch tags for fledge workflow to avoid unnecessary NEWS entries (#30).
-
-- Use larger retry count for lock-threads workflow (#28).
-
-- Ignore errors when removing pkg-config on macOS (#23).
-
-- Explicit permissions (#21).
-
-- Use styler from main branch (#19).
-
-- Need to install R on Ubuntu 24.04 (#17).
-
-- Fix macOS (#16).
-
-- Use Ubuntu 24.04 and styler PR (#15).
-
-## Documentation
-
-- Dev mode.
 
 
 # bindr 0.1.2 (2024-11-21)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-bindr 0.1.2
+bindr 0.1.3
 
 ## Cran Repository Policy
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-12-01, problems found: https://cran.r-project.org/web/checks/check_results_bindr.html
- [ ] ERROR: r-devel-linux-x86_64-debian-clang, r-patched-linux-x86_64, r-release-linux-x86_64
     Running ‘testthat.R’ [1s/2s]
     Running the tests in ‘tests/testthat.R’ failed.
     Complete output:
     > library(testthat)
     > library(bindr)
     > 
     > test_check("bindr")
     Saving _problems/test-error-13.R
     [ FAIL 1 | WARN 0 | SKIP 0 | PASS 41 ]
     
     ══ Failed tests ════════════════════════════════════════════════════════════════
     ── Error ('test-error.R:9:3'): non-native encoding causes warning ──────────────
     <lifecycle_error_deprecated/defunctError/rlang_error/error/condition>
     Error: `with_mock()` was deprecated in testthat 3.2.0 and is now defunct.
     ℹ Please use `with_mocked_bindings()` instead.
     Backtrace:
     ▆
     1. └─testthat::with_mock(...) at test-error.R:9:3
     2.   └─lifecycle::deprecate_stop("3.2.0", "with_mock()", "with_mocked_bindings()")
     3.     └─lifecycle:::deprecate_stop0(msg)
     4.       └─rlang::cnd_signal(...)
     
     [ FAIL 1 | WARN 0 | SKIP 0 | PASS 41 ]
     Error:
     ! Test failures.
     Execution halted
- [ ] ERROR: r-devel-linux-x86_64-debian-gcc
     Running ‘testthat.R’ [1s/1s]
     Running the tests in ‘tests/testthat.R’ failed.
     Complete output:
     > library(testthat)
     > library(bindr)
     > 
     > test_check("bindr")
     Saving _problems/test-error-13.R
     [ FAIL 1 | WARN 0 | SKIP 0 | PASS 41 ]
     
     ══ Failed tests ════════════════════════════════════════════════════════════════
     ── Error ('test-error.R:9:3'): non-native encoding causes warning ──────────────
     <lifecycle_error_deprecated/defunctError/rlang_error/error/condition>
     Error: `with_mock()` was deprecated in testthat 3.2.0 and is now defunct.
     ℹ Please use `with_mocked_bindings()` instead.
     Backtrace:
     ▆
     1. └─testthat::with_mock(...) at test-error.R:9:3
     2.   └─lifecycle::deprecate_stop("3.2.0", "with_mock()", "with_mocked_bindings()")
     3.     └─lifecycle:::deprecate_stop0(msg)
     4.       └─rlang::cnd_signal(...)
     
     [ FAIL 1 | WARN 0 | SKIP 0 | PASS 41 ]
     Error:
     ! Test failures.
     Execution halted
- [ ] ERROR: r-devel-linux-x86_64-fedora-clang, r-devel-linux-x86_64-fedora-gcc
     Running ‘testthat.R’
     Running the tests in ‘tests/testthat.R’ failed.
     Complete output:
     > library(testthat)
     > library(bindr)
     > 
     > test_check("bindr")
     Saving _problems/test-error-13.R
     [ FAIL 1 | WARN 0 | SKIP 0 | PASS 41 ]
     
     ══ Failed tests ════════════════════════════════════════════════════════════════
     ── Error ('test-error.R:9:3'): non-native encoding causes warning ──────────────
     <lifecycle_error_deprecated/defunctError/rlang_error/error/condition>
     Error: `with_mock()` was deprecated in testthat 3.2.0 and is now defunct.
     ℹ Please use `with_mocked_bindings()` instead.
     Backtrace:
     ▆
     1. └─testthat::with_mock(...) at test-error.R:9:3
     2.   └─lifecycle::deprecate_stop("3.2.0", "with_mock()", "with_mocked_bindings()")
     3.     └─lifecycle:::deprecate_stop0(msg)
     4.       └─rlang::cnd_signal(...)
     
     [ FAIL 1 | WARN 0 | SKIP 0 | PASS 41 ]
     Error:
     ! Test failures.
     Execution halted
- [ ] ERROR: r-release-windows-x86_64, r-oldrel-windows-x86_64
     Running 'testthat.R' [2s]
     Running the tests in 'tests/testthat.R' failed.
     Complete output:
     > library(testthat)
     > library(bindr)
     > 
     > test_check("bindr")
     Saving _problems/test-error-13.R
     [ FAIL 1 | WARN 0 | SKIP 0 | PASS 41 ]
     
     ══ Failed tests ════════════════════════════════════════════════════════════════
     ── Error ('test-error.R:9:3'): non-native encoding causes warning ──────────────
     <lifecycle_error_deprecated/defunctError/rlang_error/error/condition>
     Error: `with_mock()` was deprecated in testthat 3.2.0 and is now defunct.
     ℹ Please use `with_mocked_bindings()` instead.
     Backtrace:
     ▆
     1. └─testthat::with_mock(...) at test-error.R:9:3
     2.   └─lifecycle::deprecate_stop("3.2.0", "with_mock()", "with_mocked_bindings()")
     3.     └─lifecycle:::deprecate_stop0(msg)
     4.       └─rlang::cnd_signal(...)
     
     [ FAIL 1 | WARN 0 | SKIP 0 | PASS 41 ]
     Error:
     ! Test failures.
     Execution halted

Check results at: https://cran.r-project.org/web/checks/check_results_bindr.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`